### PR TITLE
Standardize pseudoreaction names

### DIFF
--- a/ome/loading/parse.py
+++ b/ome/loading/parse.py
@@ -82,6 +82,183 @@ def remove_boundary_metabolites(model):
     model.metabolites._generate_index()
 
 
+# --------------------------------------------------------------------
+# pseudoreactions
+# --------------------------------------------------------------------
+
+class ConflictingPseudoreaction(Exception):
+    pass
+
+
+def _has_gene_reaction_rule(reaction):
+    """Check if the reaction has a gene reaction rule."""
+    rule = getattr(reaction, 'gene_reaction_rule', None)
+    return rule is not None and rule.strip() != ''
+
+
+def _reaction_single_met_coeff(reaction):
+    if len(reaction.metabolites) == 1:
+        return reaction.metabolites.iteritems().next()
+    return None
+
+
+def _reverse_reaction(reaction):
+    """Reverse the metabolite coefficients and the upper & lower bounds."""
+    reaction.add_metabolites({k: -v for k, v in reaction.metabolites.iteritems()},
+                             combine=False)
+    reaction.upper_bound, reaction.lower_bound = -reaction.lower_bound, -reaction.upper_bound
+    logging.debug('Reversing pseudoreaction %s' % reaction.id)
+
+
+def _fix_exchange(reaction):
+    """Returns new id if the reaction was treated as an exchange."""
+    # does it look like an exchange?
+    met_coeff = _reaction_single_met_coeff(reaction)
+    if met_coeff is None:
+        return None
+    met, coeff = met_coeff
+    if split_compartment(met.id)[1] != 'e':
+        return None
+    # check id
+    if not re.search(r'^ex_', reaction.id, re.IGNORECASE):
+        raise ConflictingPseudoreaction('Reaction {r.id} looks like an exchange '
+                                        'but it does not start with EX_'
+                                        .format(r=reaction))
+    # check coefficient
+    if abs(coeff) != 1:
+        raise ConflictingPseudoreaction('Reaction {} looks like an exchange '
+                                        'but it has a reactant with coefficient {}'
+                                        .format(reaction.id, coeff))
+    # reverse if necessary
+    if coeff == 1:
+        _reverse_reaction(reaction)
+    return 'EX_%s' % met.id
+
+
+# for sink & demand functions
+_sink_regex = re.compile(r'^(sink|sk)_', re.IGNORECASE)
+
+
+def _fix_demand(reaction):
+    """Returns new ID if the reaction was treated as a demand."""
+    # does it look like a demand?
+    met_coeff = _reaction_single_met_coeff(reaction)
+    if met_coeff is None:
+        return None
+    met, coeff = met_coeff
+    if split_compartment(met.id)[1] == 'e':
+        return None
+    # source bound should be 0
+    if ((coeff > 0 and reaction.upper_bound != 0) or
+        (coeff < 0 and reaction.lower_bound != 0)):
+        return None
+    # if it could be a demand, but it is named sink_ or SK_, then let it be a
+    # sink (by returning None) because sink is really a superset of demand
+    if _sink_regex.search(reaction.id):
+        return None
+    # check id
+    if not re.search(r'^dm_', reaction.id, re.IGNORECASE):
+        raise ConflictingPseudoreaction('Reaction {r.id} looks like a demand '
+                                        'but it does not start with DM_'
+                                        .format(r=reaction))
+    # check coefficient
+    if abs(coeff) != 1:
+        raise ConflictingPseudoreaction('Reaction {} looks like a demand '
+                                        'but it has a reactant with coefficient {}'
+                                        .format(reaction.id, coeff))
+    # reverse if necessary
+    if coeff == 1:
+        _reverse_reaction(reaction)
+    return 'DM_%s' % met.id
+
+
+def _fix_sink(reaction):
+    """Returns new ID if the reaction was treated as a sink."""
+    # does it look like a sink?
+    met_coeff = _reaction_single_met_coeff(reaction)
+    if met_coeff is None:
+        return None
+    met, coeff = met_coeff
+    if split_compartment(met.id)[1] == 'e':
+        return None
+    # check id
+    if not _sink_regex.search(reaction.id):
+        raise ConflictingPseudoreaction('Reaction {r.id} looks like a sink '
+                                        'but it does not start with sink_ or SK_'
+                                        .format(r=reaction))
+    # check coefficient
+    if abs(coeff) != 1:
+        raise ConflictingPseudoreaction('Reaction {} looks like a sink '
+                                        'but it has a reactant with coefficient {}'
+                                        .format(reaction.id, coeff))
+    # reverse if necessary
+    if coeff == 1:
+        _reverse_reaction(reaction)
+    return 'SK_%s' % met.id
+
+
+def _fix_biomass(reaction):
+    """Returns new ID if the reaction was treated as a biomass."""
+    # does it look like an exchange?
+    regex = re.compile(r'biomass', re.IGNORECASE)
+    if not regex.search(reaction.id):
+        return None
+    return ('BIOMASS_%s' % regex.sub('', reaction.id)).replace('__', '_')
+
+
+def _fix_atpm(reaction):
+    """Returns new ID if the reaction was treated as a biomass."""
+    # does it look like a atpm?
+    mets = {k.id: v for k, v in reaction.metabolites.iteritems()}
+    if mets == {'atp_c': -1, 'h2o_c': -1, 'pi_c': 1, 'h_c': 1, 'adp_c': 1}:
+        return 'ATPM'
+    elif mets == {'atp_c': 1, 'h2o_c': 1, 'pi_c': -1, 'h_c': -1, 'adp_c': -1}:
+        _reverse_reaction(reaction)
+        return 'ATPM'
+    return None
+
+
+def _normalize_pseudoreaction(reaction):
+    """If the reaction is a pseudoreaction (exchange, demand, sink, biomass, or
+    ATPM), then apply standard rules to it."""
+
+    new_id = None
+
+    # check atpm separately because there is a good reason for an atpm-like
+    # reaction with a gene_reaction_rule
+    is_atpm = False
+    if new_id is None:
+        new_id = _fix_atpm(reaction)
+        if new_id is not None:
+            is_atpm = True
+
+    # check for other pseudoreactions
+    fns = [_fix_exchange, _fix_demand, _fix_sink, _fix_biomass]
+    for fn in fns:
+        if new_id is not None:
+            break
+        new_id = fn(reaction)
+
+    if new_id is not None:
+        # does it have a gene_reaction_rule? OK if atpm reaction has
+        # gene_reaction_rule.
+        if _has_gene_reaction_rule(reaction):
+            if is_atpm:
+                return
+            raise ConflictingPseudoreaction('Reaction {r.id} looks like a pseudoreaction '
+                                            'but it has a gene_reaction_rule: '
+                                            '{r.gene_reaction_rule}'.format(r=reaction))
+        # rename
+        if reaction.id != new_id:
+            logging.debug('Renaming pseudoreaction %s to %s' % (reaction.id, new_id))
+            reaction.id = new_id
+    return
+
+
+# --------------------------------------------------------------------
+# ID fixes
+# --------------------------------------------------------------------
+
 def convert_ids(model):
     """Converts metabolite and reaction ids to the new style.
 
@@ -113,12 +290,19 @@ def convert_ids(model):
 
     # separate ids and compartments, and convert to the new_id_style
     for reaction in model.reactions:
-        new_id = id_for_new_id_style(fix_legacy_id(reaction.id, use_hyphens=False))
+        # save the original id
+        current_id = reaction.id
+        # apply new id style
+        reaction.id = id_for_new_id_style(fix_legacy_id(reaction.id, use_hyphens=False))
+        # normalize pseudoreaction IDs
+        try:
+            _normalize_pseudoreaction(reaction)
+        except ConflictingPseudoreaction as e:
+            logging.warn(str(e))
         # don't merge reactions with conflicting new_id's
-        while new_id in reaction_id_dict:
-            new_id = increment_id(new_id)
-        reaction_id_dict[new_id].append(reaction.id)
-        reaction.id = new_id
+        while reaction.id in reaction_id_dict:
+            reaction.id = increment_id(reaction.id)
+        reaction_id_dict[reaction.id].append(current_id)
         # fix the gene reaction rules
         reaction.gene_reaction_rule = _check_rule_prefs(rule_prefs, reaction.gene_reaction_rule)
     model.reactions._generate_index()
@@ -144,6 +328,7 @@ def convert_ids(model):
                'reactions': reaction_id_dict,
                'genes': gene_id_dict}
     return model, old_ids
+
 
 # the regex to separate the base id, the chirality ('_L') and the compartment ('_c')
 reg_compartment = re.compile(r'(.*?)[_\(\[]([a-z][a-z0-9]?)[_\)\]]?$')
@@ -198,6 +383,10 @@ def get_formulas_from_names(model):
                 metabolite.formula = str(m.group(1))
     return model
 
+
+# --------------------------------------------------------------------
+# model setup
+# --------------------------------------------------------------------
 
 def setup_model(model, substrate_reactions, aerobic=True, sur=10, max_our=10,
                 id_style='cobrapy', fix_iJO1366=False):

--- a/ome/loading/tests/test_parse.py
+++ b/ome/loading/tests/test_parse.py
@@ -42,6 +42,7 @@ def test__normalize_pseudoreaction_exchange():
     reaction.upper_bound = 0
     _normalize_pseudoreaction(reaction)
     assert reaction.id == 'EX_glu__L_e'
+    assert reaction.subsystem == 'Extracellular exchange'
 
 
 def test__normalize_pseudoreaction_exchange_reversed():
@@ -68,10 +69,8 @@ def test__normalize_pseudoreaction_exchange_error_bad_coeff():
 def test__normalize_pseudoreaction_exchange_error_bad_name():
     reaction = Reaction('gone')
     reaction.add_metabolites({Metabolite('glu__L_e'): -1})
-    with pytest.raises(ConflictingPseudoreaction) as excinfo:
-        _normalize_pseudoreaction(reaction)
-    assert 'does not start with EX_' in str(excinfo.value)
-    assert reaction.id == 'gone'
+    _normalize_pseudoreaction(reaction)
+    assert reaction.id == 'EX_glu__L_e'
 
 
 def test__normalize_pseudoreaction_exchange_error_has_gpr():
@@ -91,6 +90,7 @@ def test__normalize_pseudoreaction_demand():
     reaction.upper_bound = 1000
     _normalize_pseudoreaction(reaction)
     assert reaction.id == 'DM_glu__L_c'
+    assert reaction.subsystem == 'Intracellular demand'
 
 
 def test__normalize_pseudoreaction_demand_reversed():
@@ -134,6 +134,7 @@ def test__normalize_pseudoreaction_sink():
     reaction.upper_bound = 0
     _normalize_pseudoreaction(reaction)
     assert reaction.id == 'SK_glu__L_c'
+    assert reaction.subsystem == 'Intracellular source/sink'
 
 
 def test__normalize_pseudoreaction_sink_reversed():
@@ -152,6 +153,7 @@ def test__normalize_pseudoreaction_biomass():
     reaction = Reaction('my_biomass_2')
     _normalize_pseudoreaction(reaction)
     assert reaction.id == 'BIOMASS_my_2'
+    assert reaction.subsystem == 'Biomass and maintenance functions'
 
 
 def test__normalize_pseudoreaction_biomass_has_gpr():
@@ -172,6 +174,7 @@ def test__normalize_pseudoreaction_atpm():
                               Metabolite('adp_c'): 1})
     _normalize_pseudoreaction(reaction)
     assert reaction.id == 'ATPM'
+    assert reaction.subsystem == 'Biomass and maintenance functions'
 
 
 def test__normalize_pseudoreaction_atpm_reversed():
@@ -210,7 +213,7 @@ def test_convert_ids_dad_2(convert_ids_model):
     returned, old_ids = convert_ids_model
     assert returned.id == 'A_bad_id'
     assert 'dad_2_c' in returned.metabolites
-    assert 'dad_2_c' in [x.id for x in returned.reactions.get_by_id('DADA').metabolites]
+    assert 'dad_2_c' in [x.id for x in returned.reactions.get_by_id('DM_dad_2_c').metabolites]
     assert ('dad_2_c', ['dad_DASH_2_c']) in old_ids['metabolites'].items()
 
 

--- a/ome/tests/test_util.py
+++ b/ome/tests/test_util.py
@@ -20,12 +20,12 @@ def test_make_reaction_copy_id():
 
 def test_check_pseudoreaction():
     assert check_pseudoreaction('ATPM') is True
-    assert check_pseudoreaction('ATPM_NGAM') is True
     assert check_pseudoreaction('ATPM1') is False
     assert check_pseudoreaction('EX_glc_e') is True
     assert check_pseudoreaction('aEX_glc_e') is False
-    assert check_pseudoreaction('biomass_objective') is True
-    assert check_pseudoreaction('BiomassEcoli') is True
+    assert check_pseudoreaction('SK_glc_e') is True
+    assert check_pseudoreaction('BIOMASS_objective') is True
+    assert check_pseudoreaction('BiomassEcoli') is False
     assert check_pseudoreaction('DM_8') is True
 
 

--- a/ome/util.py
+++ b/ome/util.py
@@ -26,11 +26,11 @@ def make_reaction_copy_id(bigg_id, copy_number):
 
 def check_pseudoreaction(reaction_id):
     patterns = [
-        r'^ATPM$', r'^ATPM_NGAM$',
+        r'^ATPM$',
         r'^EX_.*',
         r'^DM_.*',
-        r'^sink_.*',
-        r'(?i).*biomass.*' # case insensitive
+        r'^SK_.*',
+        r'^BIOMASS_.*' # case insensitive
     ]
     for pattern in patterns:
         if re.match(pattern, reaction_id):


### PR DESCRIPTION
- Standardized names for biomass, sink, exchange, atpm, and demand reactions
- Uses the prefixes EX_, DM_, SK_, BIOMASS_, and ATPM
- If pseudoreactions have gpr's, then log a warning
- If DM_, SK_, or EX_ have coefficients not 1 or -1, then log a warning
- Closes SBRG/bigg_models#84, SBRG/bigg_models#149, SBRG/bigg_models#175

I'm still testing this.